### PR TITLE
Refactor the asynchronous process_spider_output documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -229,10 +229,11 @@ Extending Scrapy
    topics/downloader-middleware
    topics/spider-middleware
    topics/extensions
-   topics/api
    topics/signals
    topics/scheduler
    topics/exporters
+   topics/components
+   topics/api
 
 
 :doc:`topics/architecture`
@@ -247,9 +248,6 @@ Extending Scrapy
 :doc:`topics/extensions`
     Extend Scrapy with your custom functionality
 
-:doc:`topics/api`
-    Use it on extensions and middlewares to extend Scrapy functionality
-
 :doc:`topics/signals`
     See all available signals and how to work with them.
 
@@ -258,6 +256,13 @@ Extending Scrapy
 
 :doc:`topics/exporters`
     Quickly export your scraped items to a file (XML, CSV, etc).
+
+:doc:`topics/components`
+    Learn the common API and some good practices when building custom Scrapy
+    components.
+
+:doc:`topics/api`
+    Use it on extensions and middlewares to extend Scrapy functionality
 
 
 All the rest

--- a/docs/topics/asyncio.rst
+++ b/docs/topics/asyncio.rst
@@ -96,3 +96,27 @@ Futures. Scrapy provides two helpers for this:
          down to Scrapy 2.0 (earlier versions do not support
          :mod:`asyncio`), you can copy the implementation of these functions
          into your own code.
+
+
+.. _enforce-asyncio-requirement:
+
+Enforcing asyncio as a requirement
+==================================
+
+If you are writing a :ref:`component <topics-components>` that requires asyncio
+to work, use :func:`scrapy.utils.reactor.is_asyncio_reactor_installed` to
+:ref:`enforce it as a requirement <enforce-component-requirements>`. For
+example::
+
+    from scrapy.utils.reactor import is_asyncio_reactor_installed
+
+    class MyComponent:
+
+        def __init__(self):
+            if not is_asyncio_reactor_installed():
+                raise ValueError(
+                    f"{MyComponent.__qualname__} requires the asyncio Twisted "
+                    f"reactor. Make sure you have it configured in the "
+                    f"TWISTED_REACTOR setting. See the asyncio documentation "
+                    f"of Scrapy for more information."
+                )

--- a/docs/topics/components.rst
+++ b/docs/topics/components.rst
@@ -1,0 +1,84 @@
+.. _topics-components:
+
+==========
+Components
+==========
+
+A Scrapy component is any class whose objects are created using
+:func:`scrapy.utils.misc.create_instance`.
+
+That includes the classes that you may assign to the following settings:
+
+-   :setting:`DNS_RESOLVER`
+
+-   :setting:`DOWNLOAD_HANDLERS`
+
+-   :setting:`DOWNLOADER_CLIENTCONTEXTFACTORY`
+
+-   :setting:`DOWNLOADER_MIDDLEWARES`
+
+-   :setting:`DUPEFILTER_CLASS`
+
+-   :setting:`EXTENSIONS`
+
+-   :setting:`FEED_EXPORTERS`
+
+-   :setting:`FEED_STORAGES`
+
+-   :setting:`ITEM_PIPELINES`
+
+-   :setting:`SCHEDULER`
+
+-   :setting:`SCHEDULER_DISK_QUEUE`
+
+-   :setting:`SCHEDULER_MEMORY_QUEUE`
+
+-   :setting:`SCHEDULER_PRIORITY_QUEUE`
+
+-   :setting:`SPIDER_MIDDLEWARES`
+
+Third-party Scrapy components may also let you define additional Scrapy
+components, usually configurable through :ref:`settings <topics-settings>`, to
+modify their behavior.
+
+.. _enforce-component-requirements:
+
+Enforcing component requirements
+================================
+
+Sometimes, your components may only be intended to work under certain
+conditions. For example, the may require a minimum version of Scrapy to work as
+intended, or they may require certain settings to have specific values.
+
+In addition to describing those conditions in the documentation of your
+component, it is a good practice to raise an exception from the ``__init__``
+method of your component if those conditions are not met at run time.
+
+In the case of :ref:`downloader middlewares <topics-downloader-middleware>`,
+:ref:`extensions <topics-extensions>`, :ref:`item pipelines
+<topics-item-pipeline>`, and :ref:`spider middlewares
+<topics-spider-middleware>`, you should raise
+:exc:`scrapy.exceptions.NotConfigured`, passing a description of the issue as a
+parameter to the exception so that it is printed in the logs, for the user to
+see. For other components, feel free to raise whatever other exception feels
+right to you; for example, :exc:`RuntimeError` would make sense for a Scrapy
+version mismatch, while :exc:`ValueError` may be better if the issue is the
+value of a setting.
+
+If your requirement is a minimum Scrapy version, you may use
+:attr:`scrapy.__version__` to enforce your requirement. For example::
+
+    from pkg_resources import parse_version
+
+    import scrapy
+
+    class MyComponent:
+
+        def __init__(self):
+            if parse_version(scrapy.__version__) < parse_version('VERSION'):
+                raise RuntimeError(
+                    f"{MyComponent.__qualname__} requires Scrapy VERSION or "
+                    f"later, which allow defining the process_spider_output "
+                    f"method of spider middlewares as an asynchronous "
+                    f"generator."
+                )

--- a/docs/topics/coroutines.rst
+++ b/docs/topics/coroutines.rst
@@ -155,6 +155,9 @@ synchronous ``process_spider_output`` method gets a synchronous iterable as its
     ``Request`` callback or ``process_spider_output`` method, none of that
     output will be processed.
 
+    This contrasts with the regular behavior, where all items yielded before
+    an exception raises are processed.
+
 Asynchronous-to-synchronous conversions are supported for backward
 compatibility, but they are deprecated and will stop working in a future
 version of Scrapy.

--- a/docs/topics/coroutines.rst
+++ b/docs/topics/coroutines.rst
@@ -162,7 +162,7 @@ Asynchronous-to-synchronous conversions are supported for backward
 compatibility, but they are deprecated and will stop working in a future
 version of Scrapy.
 
-To avoid asynchronous-to-synchronous conversion, when defining ``Request``
+To avoid asynchronous-to-synchronous conversions, when defining ``Request``
 callbacks as coroutine methods or when using spider middlewares whose
 ``process_spider_output`` method is an :term:`asynchronous generator`, all
 active spider middlewares must either have their ``process_spider_output``
@@ -177,8 +177,8 @@ process_spider_output_async method <universal-spider-middleware>`.
 
 .. _universal-spider-middleware:
 
-Universal spider middleware
-===========================
+Universal spider middlewares
+============================
 
 .. versionadded:: VERSION
 

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -98,10 +98,6 @@ object gives you access, for example, to the :ref:`settings <topics-settings>`.
 
     .. method:: process_spider_output(response, result, spider)
 
-        .. versionchanged:: VERSION
-           Since VERSION this can take and return an :term:`python:asynchronous
-           iterable`.
-
         This method is called with the results returned from the Spider, after
         it has processed the response.
 
@@ -109,8 +105,15 @@ object gives you access, for example, to the :ref:`settings <topics-settings>`.
         :class:`~scrapy.Request` objects and :ref:`item objects
         <topics-items>`.
 
-        .. note:: When defined as a :ref:`coroutine <async>`, this method needs
-                  to be an async generator, not just return an iterable.
+        .. versionchanged:: VERSION
+           This method may be defined as an :term:`asynchronous generator`, in
+           which case ``result`` is an :term:`asynchronous iterable`.
+
+        Consider defining this method as an :term:`asynchronous generator`,
+        which will be a requirement in a future version of Scrapy. However, if
+        you wish your spider middleware to work with Scrapy versions earlier
+        than Scrapy VERSION, :ref:`make your spider middleware universal
+        <universal-spider-middleware>` instead.
 
         :param response: the response which generated this output from the
           spider
@@ -127,10 +130,9 @@ object gives you access, for example, to the :ref:`settings <topics-settings>`.
 
         .. versionadded:: VERSION
 
-        If exists, this methid will be called instead of
-        :meth:`process_spider_output` when ``result`` is an async iterable.
-        If this method exists, it must be a coroutine while
-        :meth:`process_spider_output` must not be a coroutine.
+        If defined, this method must be an :term:`asynchronous generator`,
+        which will be called instead of :meth:`process_spider_output` if
+        ``result`` is an :term:`asynchronous iterable`.
 
     .. method:: process_spider_exception(response, exception, spider)
 

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -111,9 +111,11 @@ object gives you access, for example, to the :ref:`settings <topics-settings>`.
 
         Consider defining this method as an :term:`asynchronous generator`,
         which will be a requirement in a future version of Scrapy. However, if
-        you wish your spider middleware to work with Scrapy versions earlier
-        than Scrapy VERSION, :ref:`make your spider middleware universal
-        <universal-spider-middleware>` instead.
+        you plan on sharing your spider middleware with other people, consider
+        either :ref:`enforcing Scrapy VERSION <enforce-component-requirements>`
+        as a minimum requirement of your spider middleware, or :ref:`making
+        your spider middleware universal <universal-spider-middleware>` so that
+        it works with Scrapy versions earlier than Scrapy VERSION.
 
         :param response: the response which generated this output from the
           spider


### PR DESCRIPTION
I am suggesting a refactoring of the documentation.

These are some of the ideas behind this suggestion:

-   I would avoid future references as much as possible where user action is
    not needed, i.e. do not mention that this will apply to
    ``process_start_requests`` in the future, and write the documentation with
    the current situation in mind only (talking about “these methods” when it
    only applies to 1 method at the time can be confusing; I don’t think being
    able to avoid editing some lines of documentation in the future is worth
    it).

-   I would stick to the vocabulary as defined in the Python glossary to
    minimize confusion, and include links to the glossary in the first
    reference in any section.

-   I take it “they can take a normal one and return an async one” was a
    remnant from a previous iteration, before the current universal approach,
    and I have removed that.

-   I have aimed at removing references to what Scrapy does except for the
    specific scenario where user action is needed (asynchronous-to-synchronous
    conversion), instead focusing on what the user will do and get (how they
    need to define their methods, and expected input parameter types).

Pending aspects that I want to test or research before this pull request can be
reviewed:

-   [x] What happens in the case of a coroutine that returns an iterable? Would
    the user get a helpful error message? Otherwise, should we conver something
    here or in the FAQ to help users figure out what they did wrong?

    >   I am suggesting a more specific error message for this scenario, and I
    >   think that is enough, i.e. no need to cover this specifically in the
    >   documentation, where we already specifically indicate that an
    >   asynchronous generator must be used.

-   [x] Do async request callbacks need to be asynchronous generators (i.e..
    use yield) or can they return values instead? How does our inspect code
    behave if they combine yield and return?

    >   They can be regular coroutines, and support the same output values as
    >   synchronous functions.
    >
    >   Our code that checks that yield is not combined with a valued return
    >   is irrelevant here because doing that in a coroutine causes a syntax
    >   error altogether.

-   [x] When an exception happens as part of an async-to-sync conversion, what
    happens exactly? Are all items skipped always? Are items processed before
    the exception still passed forward? How do things behave in similar
    scenarios not involving a conversion, either all sync or all async? What
    is the behavior on sync-to-async conversions?

    >   Since this is not explained in the regular spider middleware
    >   documentation, as far as I can tell, I have extended the corresponding
    >   point of the new documentation to clarify that, when there is no
    >   async-to-sync conversion, items yielded before an exception is raised
    >   are processed.
    >
    >   Also, this scenario seems covered by tests at
    >   `tests/test_spidermiddleware_output_chain.py`.

-   [x] The current documentation says:

    >   Async iterables returned from
    >   :meth:`~scrapy.spidermiddlewares.SpiderMiddleware.process_spider_exception`
    >   won't be downgraded, an exception will be raised if that is needed.

    What does that mean, exactly? Can process_spider_exception be defined as a
    coroutine?

    >   We decided not to document coroutine support for this method for now.
    >
    >   Later on we will figure out what to do with its coroutine API.

-   [x] Restore the tip about using ``scrapy.__version__`` when writing
    async-only middlewares. Maybe we could give it its own section, and include
    an example. And maybe we could write an asyncio counterpart section in the
    asyncio page, featuring gracefully disabling Scrapy components if an
    asyncio reactor is not being used, also featuring an example.
    
    >   Done through a new documentation page that may also be used for
    >   https://github.com/scrapy/scrapy/issues/5110
