### PR TITLE
Documentation changes

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1366,8 +1366,8 @@ Highlights:
 
 -   Added the :reqmeta:`allow_offsite` request meta key
 
--   :ref:`Spider middlewares that don't support asynchronous spider output
-    <sync-async-spider-middleware>` are deprecated
+-   Spider middlewares that don't support asynchronous spider output are
+    deprecated.
 
 -   Added a base class for :ref:`universal spider middlewares
     <universal-spider-middleware>`
@@ -1505,13 +1505,11 @@ Deprecations
     ``start_queue_cls`` parameter.
     (:issue:`6752`)
 
--   :ref:`Spider middlewares that don't support asynchronous spider output
-    <sync-async-spider-middleware>` are deprecated. The async iterable
-    downgrading feature, needed for using such middlewares with asynchronous
-    callbacks and with other spider middlewares that produce asynchronous
-    iterables, is also deprecated. Please update all such middlewares to
-    support asynchronous spider output.
-    (:issue:`6664`)
+-   Spider middlewares that don't support asynchronous spider output are
+    deprecated. The async iterable downgrading feature, needed for using such
+    middlewares with asynchronous callbacks and with other spider middlewares
+    that produce asynchronous iterables, is also deprecated. Please update all
+    such middlewares to support asynchronous spider output. (:issue:`6664`)
 
 -   Functions that were imported from :mod:`w3lib.url` and re-exported in
     :mod:`scrapy.utils.url` are now deprecated, you should import them from
@@ -1770,9 +1768,8 @@ Documentation
 -   Documented the setting values set in the default project template.
     (:issue:`6762`, :issue:`6775`)
 
--   Improved the :ref:`docs <sync-async-spider-middleware>` about asynchronous
-    iterable support in spider middlewares.
-    (:issue:`6688`)
+-   Improved the docs about asynchronous iterable support in spider
+    middlewares. (:issue:`6688`)
 
 -   Improved the :ref:`docs <coroutine-deferred-apis>` about using
     :class:`~twisted.internet.defer.Deferred`-based APIs in coroutine-based

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1367,7 +1367,7 @@ Highlights:
 -   Added the :reqmeta:`allow_offsite` request meta key
 
 -   Spider middlewares that don't support asynchronous spider output are
-    deprecated.
+    deprecated
 
 -   Added a base class for :ref:`universal spider middlewares
     <universal-spider-middleware>`

--- a/docs/topics/coroutines.rst
+++ b/docs/topics/coroutines.rst
@@ -23,9 +23,6 @@ hence use coroutine syntax (e.g. ``await``, ``async for``, ``async with``):
 
 -   :class:`~scrapy.Request` callbacks.
 
-    If you are using any custom or third-party :ref:`spider middleware
-    <topics-spider-middleware>`, see :ref:`sync-async-spider-middleware`.
-
 -   The :meth:`process_item` method of
     :ref:`item pipelines <topics-item-pipeline>`.
 
@@ -39,13 +36,9 @@ hence use coroutine syntax (e.g. ``await``, ``async for``, ``async with``):
 
 -   The
     :meth:`~scrapy.spidermiddlewares.SpiderMiddleware.process_spider_output`
-    method of :ref:`spider middlewares <topics-spider-middleware>`.
-
-    If defined as a coroutine, it must be an :term:`asynchronous generator`.
-    The input ``result`` parameter is an :term:`asynchronous iterable`.
-
-    See also :ref:`sync-async-spider-middleware` and
-    :ref:`universal-spider-middleware`.
+    method of :ref:`spider middlewares <topics-spider-middleware>`, which
+    *must* be defined as an :term:`asynchronous generator` except in
+    :ref:`universal spider middlewares <universal-spider-middleware>`.
 
 -   The :meth:`~scrapy.spidermiddlewares.SpiderMiddleware.process_start` method
     of :ref:`spider middlewares <custom-spider-middleware>`, which *must* be
@@ -277,48 +270,3 @@ You can also send multiple requests in parallel:
                 "price": responses[0][1].css(".price::text").get(),
                 "price2": responses[1][1].css(".color::text").get(),
             }
-
-
-.. _universal-spider-middleware:
-
-Universal spider middlewares
-============================
-
-To allow writing a spider middleware that supports asynchronous execution of
-its ``process_spider_output()`` method in Scrapy 2.7 and later
-while maintaining support for older Scrapy versions, you may define
-``process_spider_output()`` as a synchronous method and define an
-:term:`asynchronous generator` version of that method with an alternative name:
-``process_spider_output_async()``.
-
-For example:
-
-.. code-block:: python
-
-    class UniversalSpiderMiddleware:
-        def process_spider_output(self, response, result):
-            for r in result:
-                # ... do something with r
-                yield r
-
-        async def process_spider_output_async(self, response, result):
-            async for r in result:
-                # ... do something with r
-                yield r
-
-.. note:: This is an interim measure to allow, for a time, to write code that
-          works in Scrapy 2.7 and later without requiring
-          asynchronous-to-synchronous conversions, and works in earlier Scrapy
-          versions as well.
-
-          In some future version of Scrapy, however, this feature will be
-          deprecated and, eventually, in a later version of Scrapy, this
-          feature will be removed, and all spider middlewares will be expected
-          to define their ``process_spider_output`` method as an asynchronous
-          generator.
-
-Since 2.13.0, Scrapy provides a base class,
-:class:`~scrapy.spidermiddlewares.base.BaseSpiderMiddleware`, which implements
-the ``process_spider_output()`` and ``process_spider_output_async()`` methods,
-so instead of duplicating the processing code you can override the
-``get_processed_request()`` and/or the ``get_processed_item()`` method.

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -137,7 +137,7 @@ one or more of these methods:
         :async:
 
         Alternative name for :meth:`process_spider_output` used when
-        implementing :ref:`universal spider middlewares
+        implementing a :ref:`universal spider middleware
         <universal-spider-middleware>`.
 
     .. method:: process_spider_exception(response, exception)
@@ -174,7 +174,7 @@ Universal spider middlewares
 In Scrapy 2.6.3 and lower, ``process_spider_output()`` must be a *synchronous*
 generator.
 
-To support those versions and current Scrapy versions in the same middleware,
+To support those versions and higher Scrapy versions in the same middleware,
 rename your asynchronous :method:`~SpiderMiddleware.process_spider_output()`
 method to :method:`~SpiderMiddleware.process_spider_output_async()`, and define
 a synchronous ``process_spider_output()`` method to be used by the older

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -117,33 +117,28 @@ one or more of these methods:
         :type response: :class:`~scrapy.http.Response` object
 
     .. method:: process_spider_output(response, result)
+        :async:
 
-        This method is called with the results returned from the Spider, after
-        it has processed the response.
+        This method is an :term:`asynchronous generator` called with the
+        results from the spider after the spider has processed the response.
 
-        :meth:`process_spider_output` must return an iterable of
-        :class:`~scrapy.Request` objects and :ref:`item objects
-        <topics-items>`.
-
-        If this method is synchronous, it will be ignored and the middleware
-        is required to define an asynchronous ``process_spider_output_async()``
-        method that will be called instead. This is a temporary measure for
-        supporting middlewares that support Scrapy versions earlier than
-        Scrapy 2.7, see :ref:`universal-spider-middleware`.
+        .. seealso:: :ref:`universal-spider-middleware`.
 
         :param response: the response which generated this output from the
           spider
         :type response: :class:`~scrapy.http.Response` object
 
-        :param result: the result returned by the spider
-        :type result: an iterable of :class:`~scrapy.Request` objects and
-          :ref:`item objects <topics-items>`
+        :param result: the results from the spider
+        :type result: an :term:`asynchronous iterable` of
+        :class:`~scrapy.Request` objects and :ref:`item objects
+        <topics-items>`
 
     .. method:: process_spider_output_async(response, result)
         :async:
 
-        If defined, this method must be an :term:`asynchronous generator`,
-        which will be called instead of :meth:`process_spider_output`.
+        Alternative name for :meth:`process_spider_output` used when
+        implementing :ref:`universal spider middlewares
+        <universal-spider-middleware>`.
 
     .. method:: process_spider_exception(response, exception)
 
@@ -171,13 +166,40 @@ one or more of these methods:
         :type exception: :exc:`Exception` object
 
 
+.. _universal-spider-middleware:
+
+Universal spider middlewares
+----------------------------
+
+In Scrapy 2.6.3 and lower, ``process_spider_output()`` must be a *synchronous*
+generator.
+
+To support those versions and current Scrapy versions in the same middleware,
+rename your asynchronous :method:`~SpiderMiddleware.process_spider_output()`
+method to :method:`~SpiderMiddleware.process_spider_output_async()`, and define
+a synchronous ``process_spider_output()`` method to be used by the older
+versions.
+
+For example:
+
+.. code-block:: python
+
+    class UniversalSpiderMiddleware:
+        async def process_spider_output_async(self, response, result):
+            async for r in result:
+                # ... do something with r
+                yield r
+
+        def process_spider_output(self, response, result):
+            for r in result:
+                # ... do something with r
+                yield r
+
 Base class for custom spider middlewares
 ----------------------------------------
 
 Scrapy provides a base class for custom spider middlewares. It's not required
-to use it but it can help with simplifying middleware implementations and
-reducing the amount of boilerplate code in :ref:`universal middlewares
-<universal-spider-middleware>`.
+to use it but it can help with simplifying middleware implementations.
 
 .. module:: scrapy.spidermiddlewares.base
 

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -177,7 +177,7 @@ generator.
 To support those versions and higher Scrapy versions in the same middleware,
 rename your asynchronous :method:`~SpiderMiddleware.process_spider_output()`
 method to :method:`~SpiderMiddleware.process_spider_output_async()`, and define
-a synchronous ``process_spider_output()`` method to be used by the older
+a synchronous ``process_spider_output()`` method to be used by 2.6.3 and lower
 versions.
 
 For example:

--- a/docs/topics/spider-middleware.rst
+++ b/docs/topics/spider-middleware.rst
@@ -130,8 +130,8 @@ one or more of these methods:
 
         :param result: the results from the spider
         :type result: an :term:`asynchronous iterable` of
-        :class:`~scrapy.Request` objects and :ref:`item objects
-        <topics-items>`
+          :class:`~scrapy.Request` objects and :ref:`item objects
+          <topics-items>`
 
     .. method:: process_spider_output_async(response, result)
         :async:


### PR DESCRIPTION
I feel like we need to rewrite the universal section and related docs from a new perspective now:
- I think it now makes more sense in the spider middlewares page.
- It is not about how to support 2.7+, it is about how to support 2.6.3-.
- The note about the "interim" state is not needed anymore; instead, when we deprecate the universal approach, we simply remove the universal section altogether.
- `BaseSpiderMiddleware` is irrelevant in the context of universal support, since it was introduced after 2.6.3.

I also think that the reference docs of the methods should be about the async approach only, with the optional sync version of the main method name being an afterthought only covered in the universal section.

I have also removed some references to the now-removed `sync-async-spider-middleware`.